### PR TITLE
Add a function for ambient authorities known at compile time.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -11,6 +11,10 @@ disallowed-methods = [
   # Crates that explicitly declare their ambient authorities require this.
   "ambient_authority::ambient_authority",
 
+  # By default we warn about ambient authorities known at compile time as well;
+  # comment this out if you're only interested in dynamic ambient authority.
+  "ambient_authority::ambient_authority_known_at_compile_time",
+
   # Use cap-std instead.
   "std::fs::canonicalize",
   "std::fs::copy",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,19 @@ pub struct AmbientAuthority(());
 pub fn ambient_authority() -> AmbientAuthority {
     AmbientAuthority(())
 }
+
+/// Internal implementation detail for macros.
+///
+/// For users concerned about resource names such as file names or network
+/// addresses being influenced by untrusted code, file names in static string
+/// literals and network addresses in integer literals are ok. This function
+/// is similar to `ambient_authority` but is meant to be used in macros that
+/// verify that the resource identifiers are known at compile time. Users of
+/// the `disallowed_method` clippy lint can opt to allow or disallow this
+/// function separately from the general `ambient_authority` function.
+#[inline]
+#[must_use]
+#[doc(hidden)]
+pub const fn ambient_authority_known_at_compile_time() -> AmbientAuthority {
+    AmbientAuthority(())
+}


### PR DESCRIPTION
Sometimes, one is primarily concerned with resource names that may be
influenced by untrusted code at runtime, and compile-time names and
addresses are ok.

Add a new function for obtaining an `AmbientAuthority`, meant for use
by macros which confirm that their operands are literals known at
compile time. Add it to the clippy config so that we still warn about
it by default, but this way, users have the option of commenting it
out if they wish to focus on dynamic ambient authority.

This implements the ambient-authority side of bytecodealliance/cap-std#175.