### PR TITLE
Add `SeedableRng::from_entropy` to the deny-list.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -159,6 +159,7 @@ disallowed-methods = [
   "rand::rngs::ThreadRng::default",
   "rand::thread_rng",
   "rand::random",
+  "rand::SeedableRng::from_entropy",
 
   # Use cap-tempfile instead.
   "std::env::temp_dir",


### PR DESCRIPTION
Add `SeedableRng::from_entropy` to the dissallowed-methods list, as it depends on ambient authority. See bytecodealliance/cap-std#274 for details.