### PR TITLE
Add rustix APIs to the deny list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ help. To use it:
  - Manually ensure that all immediate dependencies follow the above convention.
 
  - Copy the [clippy.toml] file into the top level source directory, add
-   `#![deny(clippy::disallowed_method)]` to the root module (main.rs or lib.rs),
-   and run `cargo clippy` or equivalent.
+   `#![deny(clippy::disallowed_methods)]` to the root module (main.rs or
+   lib.rs), and run `cargo clippy` or equivalent.
 
 [cap-std]: https://docs.rs/cap-std/*/cap_std/
 [clippy.toml]: https://github.com/sunfishcode/ambient-authority/blob/main/clippy.toml

--- a/clippy.toml
+++ b/clippy.toml
@@ -179,4 +179,24 @@ disallowed-methods = [
   "fs_set_times::set_mtime",
   "fs_set_times::set_times",
   "fs_set_times::set_symlink_times",
+
+  # Rustix things that can reference specific addresses.
+  "rustix::net::bind",
+  "rustix::net::bind_v6",
+  "rustix::net::bind_v4",
+  "rustix::net::bind_unix",
+  "rustix::net::bind_any",
+  "rustix::net::connect",
+  "rustix::net::connect_v6",
+  "rustix::net::connect_v4",
+  "rustix::net::connect_unix",
+  "rustix::net::connect_any",
+  "rustix::net::sendto",
+
+  # For now, just call all of `rustix::fs` etc. ambient, even though some
+  # things like `fstat` aren't.
+  "rustix::fs",
+  "rustix::process",
+  "rustix::rand",
+  "rustix::time",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -180,7 +180,9 @@ disallowed-methods = [
   "fs_set_times::set_times",
   "fs_set_times::set_symlink_times",
 
-  # Rustix things that can reference specific addresses.
+  # rustix::net things that can reference specific addresses. For other
+  # rustix modules, we don't have all the functions listed out, so just...
+  # don't use the other modules.
   "rustix::net::bind",
   "rustix::net::bind_v6",
   "rustix::net::bind_v4",
@@ -192,11 +194,4 @@ disallowed-methods = [
   "rustix::net::connect_unix",
   "rustix::net::connect_any",
   "rustix::net::sendto",
-
-  # For now, just call all of `rustix::fs` etc. ambient, even though some
-  # things like `fstat` aren't.
-  "rustix::fs",
-  "rustix::process",
-  "rustix::rand",
-  "rustix::time",
 ]


### PR DESCRIPTION
Add rustix APIs that can reference network addresses or filesystem paths or per-process resources to the deny list.